### PR TITLE
td minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,15 @@ Very simple jupyter-based introduction to the Muon Space GNSS-R soil moisture pr
 
 Tested on macOS (Sonoma 14.3.1)
 
+> **REQUIRES python3 >=3.12:**
+
 ## Instructions
 
-1. download dataset from [Zenodo](https://zenodo.org/uploads/14172456) and unzip
-2. git clone repo
-3. cd into repo
-4. run `make venv` to build the project
-5. run `make notebooks` to launch the jupyter session
-6. open `Loading and Visualization of Muon GNSS-R Soil Moisture Products.ipynb`
-7. change `path_to_zenodo_directory` then have fun exploring the data files!
+1. download dataset from [Zenodo](https://zenodo.org/uploads/14172456)(~150GB compressed) 
+2. unzip in desired local data directory
+3. git clone repo
+4. cd into repo
+5. run `make venv` to build the project
+6. run `make notebooks` to launch the jupyter session
+7. open `Loading and Visualization of Muon GNSS-R Soil Moisture Products.ipynb`
+8. change `path_to_zenodo_directory` to local data directory path then have fun exploring the data files!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,5 @@ dependencies = [
   "geodatasets",
   "h5netcdf",
   "cartopy",
+  "notebook",
 ]


### PR DESCRIPTION
A couple minor edits based upon my experience running the repo/notebook

* minor updates to `README` making python3 requirement more explicit.
* I needed to add `notebook` package to .toml to run `make notebooks`.  
* Only ran half of notebook because each zenodo download was dropping on my connection 🐌 .  One thing to consider would be to split the tar ball up, if zenodo allows it? (eg \trackwise and \gridded are split 🤷 ).  I don't know if zenodo throttles these, but s3 will help!